### PR TITLE
Bump pyodide to 0.24.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ npm install restructedpyjs
 
 ## Usage
 
+Add the source snippet:
+
+```html
+<script src="https://cdn.jsdelivr.net/pyodide/v0.24.1/full/pyodide.asm.js"></script>
+<script src="https://unpkg.com/restructedpyjs@latest/dist/restructedpyjs.bundle.js"></script>
+```
+
+Then the following JS should work:
+
 ```js
 const RestructedPyJS = require('restructedpyjs').default;
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,8 +77,9 @@ For more information, see this `blog post <https://aws.amazon.com/blogs/develope
     <div id="output"></div>
 
 
-    <!-- <script src="https://unpkg.com/restructedpyjs@latest/dist/restructedpyjs.bundle.js"></script> -->
-    <script src="http://localhost:8000/dist/restructedpyjs.bundle.js"></script>
+    <script src="https://cdn.jsdelivr.net/pyodide/v0.24.1/full/pyodide.asm.js"></script>
+    <script src="https://unpkg.com/restructedpyjs@latest/dist/restructedpyjs.bundle.js"></script>
+    <!-- <script src="http://localhost:8000/dist/restructedpyjs.bundle.js"></script> -->
     <script>
       const rstToHtml = async (rstText) => {
         const restructedpyjs = new window.restructedpyjs.default();

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,8 +77,8 @@ For more information, see this `blog post <https://aws.amazon.com/blogs/develope
     <div id="output"></div>
 
 
-    <script src="https://unpkg.com/restructedpyjs@latest/dist/restructedpyjs.bundle.js"></script>
-    <!-- <script src="http://localhost:8000/dist/restructedpyjs.bundle.js"></script> -->
+    <!-- <script src="https://unpkg.com/restructedpyjs@latest/dist/restructedpyjs.bundle.js"></script> -->
+    <script src="http://localhost:8000/dist/restructedpyjs.bundle.js"></script>
     <script>
       const rstToHtml = async (rstText) => {
         const restructedpyjs = new window.restructedpyjs.default();

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.0.18",
             "license": "MIT",
             "dependencies": {
-                "node-fetch": "^2.6.9",
+                "axios": "^1.5.1",
                 "pyodide": "^0.24.1"
             },
             "devDependencies": {
@@ -2388,6 +2388,21 @@
                 "node": "*"
             }
         },
+        "node_modules/asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+        },
+        "node_modules/axios": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.1.tgz",
+            "integrity": "sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==",
+            "dependencies": {
+                "follow-redirects": "^1.15.0",
+                "form-data": "^4.0.0",
+                "proxy-from-env": "^1.1.0"
+            }
+        },
         "node_modules/babel-loader": {
             "version": "9.1.3",
             "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-9.1.3.tgz",
@@ -2754,6 +2769,17 @@
             "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
             "dev": true
         },
+        "node_modules/combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dependencies": {
+                "delayed-stream": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/commander": {
             "version": "2.20.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -2850,6 +2876,14 @@
             },
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "engines": {
+                "node": ">=0.4.0"
             }
         },
         "node_modules/diff": {
@@ -3152,6 +3186,38 @@
             "dev": true,
             "bin": {
                 "flat": "cli.js"
+            }
+        },
+        "node_modules/follow-redirects": {
+            "version": "1.15.3",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
+            "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/RubenVerborgh"
+                }
+            ],
+            "engines": {
+                "node": ">=4.0"
+            },
+            "peerDependenciesMeta": {
+                "debug": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/form-data": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/fs.realpath": {
@@ -3615,7 +3681,6 @@
             "version": "1.52.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
             "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-            "dev": true,
             "engines": {
                 "node": ">= 0.6"
             }
@@ -3624,7 +3689,6 @@
             "version": "2.1.35",
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
             "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-            "dev": true,
             "dependencies": {
                 "mime-db": "1.52.0"
             },
@@ -3784,44 +3848,6 @@
             "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
             "dev": true
         },
-        "node_modules/node-fetch": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
-            "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
-            "dependencies": {
-                "whatwg-url": "^5.0.0"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/node-fetch/node_modules/tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-        },
-        "node_modules/node-fetch/node_modules/webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-        },
-        "node_modules/node-fetch/node_modules/whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-            "dependencies": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
-            }
-        },
         "node_modules/node-releases": {
             "version": "2.0.13",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
@@ -3971,6 +3997,11 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
         },
         "node_modules/punycode": {
             "version": "2.3.0",
@@ -6493,6 +6524,21 @@
             "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
             "dev": true
         },
+        "asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+        },
+        "axios": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.1.tgz",
+            "integrity": "sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==",
+            "requires": {
+                "follow-redirects": "^1.15.0",
+                "form-data": "^4.0.0",
+                "proxy-from-env": "^1.1.0"
+            }
+        },
         "babel-loader": {
             "version": "9.1.3",
             "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-9.1.3.tgz",
@@ -6752,6 +6798,14 @@
             "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
             "dev": true
         },
+        "combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "requires": {
+                "delayed-stream": "~1.0.0"
+            }
+        },
         "commander": {
             "version": "2.20.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -6825,6 +6879,11 @@
             "requires": {
                 "type-detect": "^4.0.0"
             }
+        },
+        "delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
         },
         "diff": {
             "version": "5.0.0",
@@ -7035,6 +7094,21 @@
             "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
             "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
             "dev": true
+        },
+        "follow-redirects": {
+            "version": "1.15.3",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
+            "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q=="
+        },
+        "form-data": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+            "requires": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "mime-types": "^2.1.12"
+            }
         },
         "fs.realpath": {
             "version": "1.0.0",
@@ -7380,14 +7454,12 @@
         "mime-db": {
             "version": "1.52.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-            "dev": true
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
         },
         "mime-types": {
             "version": "2.1.35",
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
             "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-            "dev": true,
             "requires": {
                 "mime-db": "1.52.0"
             }
@@ -7502,35 +7574,6 @@
             "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
             "dev": true
         },
-        "node-fetch": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
-            "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
-            "requires": {
-                "whatwg-url": "^5.0.0"
-            },
-            "dependencies": {
-                "tr46": {
-                    "version": "0.0.3",
-                    "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-                    "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-                },
-                "webidl-conversions": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-                    "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-                },
-                "whatwg-url": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-                    "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-                    "requires": {
-                        "tr46": "~0.0.3",
-                        "webidl-conversions": "^3.0.0"
-                    }
-                }
-            }
-        },
         "node-releases": {
             "version": "2.0.13",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
@@ -7638,6 +7681,11 @@
             "requires": {
                 "find-up": "^4.0.0"
             }
+        },
+        "proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
         },
         "punycode": {
             "version": "2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
     "name": "restructedpyjs",
-    "version": "0.0.17",
+    "version": "0.0.18",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "restructedpyjs",
-            "version": "0.0.17",
+            "version": "0.0.18",
             "license": "MIT",
             "dependencies": {
-                "pyodide": "^0.23.4"
+                "node-fetch": "^2.6.9",
+                "pyodide": "^0.24.1"
             },
             "devDependencies": {
                 "@babel/core": "^7.21.8",
@@ -3784,9 +3785,9 @@
             "dev": true
         },
         "node_modules/node-fetch": {
-            "version": "2.6.11",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
-            "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+            "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
             "dependencies": {
                 "whatwg-url": "^5.0.0"
             },
@@ -3981,12 +3982,11 @@
             }
         },
         "node_modules/pyodide": {
-            "version": "0.23.4",
-            "resolved": "https://registry.npmjs.org/pyodide/-/pyodide-0.23.4.tgz",
-            "integrity": "sha512-WpQUHaIXQ1xede5BMqPAjBcmopxN22s5hEsYOR8T7/UW/fkNLFUn07SaemUgthbtvedD5JGymMMj4VpD9sGMTg==",
+            "version": "0.24.1",
+            "resolved": "https://registry.npmjs.org/pyodide/-/pyodide-0.24.1.tgz",
+            "integrity": "sha512-fkNolNwiv41E2KKCP2bgW+dwr95B+0KSC/WG9WCmlWM9MNFbRVX0rF9i4OikRM78bGeVUvLdVJw8jY17wxKoRQ==",
             "dependencies": {
                 "base-64": "^1.0.0",
-                "node-fetch": "^2.6.1",
                 "ws": "^8.5.0"
             }
         },
@@ -7503,9 +7503,9 @@
             "dev": true
         },
         "node-fetch": {
-            "version": "2.6.11",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
-            "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+            "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
             "requires": {
                 "whatwg-url": "^5.0.0"
             },
@@ -7646,12 +7646,11 @@
             "dev": true
         },
         "pyodide": {
-            "version": "0.23.4",
-            "resolved": "https://registry.npmjs.org/pyodide/-/pyodide-0.23.4.tgz",
-            "integrity": "sha512-WpQUHaIXQ1xede5BMqPAjBcmopxN22s5hEsYOR8T7/UW/fkNLFUn07SaemUgthbtvedD5JGymMMj4VpD9sGMTg==",
+            "version": "0.24.1",
+            "resolved": "https://registry.npmjs.org/pyodide/-/pyodide-0.24.1.tgz",
+            "integrity": "sha512-fkNolNwiv41E2KKCP2bgW+dwr95B+0KSC/WG9WCmlWM9MNFbRVX0rF9i4OikRM78bGeVUvLdVJw8jY17wxKoRQ==",
             "requires": {
                 "base-64": "^1.0.0",
-                "node-fetch": "^2.6.1",
                 "ws": "^8.5.0"
             },
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "author": "Tyler Finethy",
     "license": "MIT",
     "dependencies": {
-        "pyodide": "^0.23.4"
+        "node-fetch": "^2.6.9",
+        "pyodide": "^0.24.1"
     },
     "files": [
         "dist"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "author": "Tyler Finethy",
     "license": "MIT",
     "dependencies": {
-        "node-fetch": "^2.6.9",
+        "axios": "^1.5.1",
         "pyodide": "^0.24.1"
     },
     "files": [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,7 @@
 const path = require('path');
 
 module.exports = {
-  mode: 'development',
-  devtool: 'source-map',
+  mode: 'production',
   entry: './src/restructedpyjs.js',
   output: {
     path: path.resolve(__dirname, 'dist'),
@@ -10,6 +9,11 @@ module.exports = {
     library: 'restructedpyjs',
     libraryTarget: 'umd',
     globalObject: 'this',
+  },
+  resolve: {
+    alias: {
+      'node-fetch': 'axios',
+    }
   },
   optimization: {
     minimize: true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,8 @@
 const path = require('path');
 
 module.exports = {
-  mode: 'production',
+  mode: 'development',
+  devtool: 'source-map',
   entry: './src/restructedpyjs.js',
   output: {
     path: path.resolve(__dirname, 'dist'),


### PR DESCRIPTION
Branch with console error loading pyodide:

```
Uncaught (in promise) Error: Cannot find module 'https://cdn.jsdelivr.net/pyodide/v0.24.1/full/pyodide.asm.js'
    ./node_modules/pyodide lazy recursive/t/< lazy strict namespace object:5
    promise callback*t lazy strict namespace object:4`
```

Can be reproduced by doing:

```
npm install
npm build
python3 -m http.server
```

Navigate to localhost:8000/docs/index.html and click convert